### PR TITLE
Improve docs and comment key classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 An Android application developed to demonstrate modern development practices, clean architecture, and advanced UI construction with Jetpack Compose. The app fetches and displays cryptocurrency exchange data from the CoinAPI.io.
 
-## About the Project
+## Visão Geral do Projeto
 
-CryptoRune was developed as a technical challenge to showcase skills in modern Android development. The project is built entirely in Kotlin and utilizes a **Clean Architecture** with an **MVI (Model-View-Intent)** pattern, ensuring a scalable, maintainable, and testable codebase.
+CryptoRune é um aplicativo Android desenvolvido para demonstrar práticas modernas de desenvolvimento. Ele é escrito integralmente em Kotlin e segue os princípios da **Clean Architecture** em conjunto com o padrão **MVI (Model-View-Intent)**, oferecendo uma base escalável e de fácil manutenção.
 
-The application's core function is to consume the **CoinAPI.io** to fetch a list of cryptocurrency exchanges and display their details. Throughout its development, several advanced features were implemented to create a fluid, resilient, and visually appealing user experience. This includes a dynamic portfolio header with a custom-drawn chart, real-time currency conversion, a full-screen skeleton loading state to improve perceived performance, and a custom in-house design system named **"Pluto"** to ensure UI consistency.
+O objetivo é consumir a API da **CoinAPI.io** para exibir uma lista de corretoras de criptomoedas e seus detalhes. Recursos avançados como cabeçalho dinâmico com gráfico, conversão em tempo real de moedas, tela de carregamento com skeleton e o design system **"Pluto"** garantem uma experiência moderna e consistente.
 
 ## Screens LIGHT
 
@@ -30,15 +30,23 @@ The application's core function is to consume the **CoinAPI.io** to fetch a list
 -   **Modern Skeleton Loading UI**: A custom, full-screen skeleton loader that mimics the final layout, providing a seamless transition from loading to content.
 -   **Advanced UI Components**: Modern, animated, and interactive UI components built with Jetpack Compose.
 
-## Architecture
+## Arquitetura
 
-This project is built upon the principles of **Clean Architecture**, separating concerns into three primary layers: Data, Domain, and Presentation.
+O projeto segue os princípios da **Clean Architecture**, separando responsabilidades em três camadas principais: Data, Domain e Presentation.
+
+```
+Presentation (ViewModel & Compose)
+        |
+Domain (UseCases)
+        |
+Data (Repositories -> DataSources)
+```
 
 -   **Data Layer**: Responsible for fetching data from remote (Retrofit/CoinAPI) and local sources.
 -   **Domain Layer**: Contains the core business logic, executed through `UseCases`.
 -   **Presentation Layer**: Implements an **MVI (Model-View-Intent)** pattern using Jetpack Compose for the UI and a `ViewModel` to manage state and handle user intents.
 
-## Technologies Used
+## Tecnologias Utilizadas
 
 -   **Language**: [Kotlin](https://kotlinlang.org/)
 -   **UI Toolkit**: [Jetpack Compose](https://developer.android.com/jetpack/compose)
@@ -74,16 +82,31 @@ To run the app, you need an API key from [CoinAPI.io](https://www.coinapi.io/). 
 ### Important Notes
 -   **Security**: The `local.properties` file is included in the project's `.gitignore` to prevent your secret keys from being committed to version control. **Never commit your API keys.**
 
-### How to Run
+### Como Executar
 
-1.  Clone the repository to your local machine.
-2.  Set up your API key as described above.
-3.  Open the project in Android Studio and run the app.
+1.  Clone o repositório em sua máquina.
+2.  Configure a chave da API conforme descrito acima.
+3.  Abra o projeto no Android Studio e execute o aplicativo.
+
+### Como Rodar os Testes
+
+Execute os testes unitários e instrumentados com:
+
+```bash
+./gradlew test
+./gradlew connectedAndroidTest
+```
 
 ### Development Environment
 
 -   Android Studio | Meerkat Feature Drop | 2024.3.2 Patch 1
 -   Java JDK 17
+
+## Classes Principais
+
+- **MainActivity**: activity inicial que configura o tema, o grafo de navegação e gerencia a animação da splash screen.
+- **Repositories**: abstrações responsáveis por obter ou persistir dados. As implementações `ExchangesRepositoryImpl` e `LocalRepositoryImpl` acessam a rede e o banco local, respectivamente.
+- **ViewModel**: controla o estado das telas e responde aos intents de usuário. Exemplos incluem `MainViewModel`, `ExchangesViewModel` e `DetailsViewModel`.
 
 ## Credits
 

--- a/app/src/main/java/com/leandrocourse/cryptorune/MainActivity.kt
+++ b/app/src/main/java/com/leandrocourse/cryptorune/MainActivity.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.cryptorune
 
+/**
+ * Entry point of the application. This activity hosts the Jetpack Compose
+ * content and coordinates the navigation graph. It also handles the splash
+ * screen animation while waiting for [MainViewModel] to finish loading data.
+ */
+
 import android.os.Bundle
 import android.view.animation.AnticipateInterpolator
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/leandrocourse/cryptorune/application/MainViewModel.kt
+++ b/app/src/main/java/com/leandrocourse/cryptorune/application/MainViewModel.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.cryptorune.application
 
+/**
+ * ViewModel used by [com.leandrocourse.cryptorune.MainActivity] to keep track
+ * of the app loading state. It simply delays for a short period to display the
+ * splash screen before allowing the UI to render.
+ */
+
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.delay

--- a/core/data/local/src/main/java/com/leandrocourse/core/data/local/repository/LocalRepositoryImpl.kt
+++ b/core/data/local/src/main/java/com/leandrocourse/core/data/local/repository/LocalRepositoryImpl.kt
@@ -1,5 +1,10 @@
 package com.leandrocourse.core.data.local.repository
 
+/**
+ * Local implementation of [MBCryptoRuneRepository]. It persists and retrieves
+ * exchange information using the provided [LocalDataSource].
+ */
+
 import com.leandrocourse.core.data.local.source.LocalDataSource
 import com.leandrocourse.core.domain.model.Exchange
 import com.leandrocourse.core.domain.repository.MBCryptoRuneRepository

--- a/features/details/src/main/java/com/leandrocourse/features/details/presentation/viewmodel/DetailsViewModel.kt
+++ b/features/details/src/main/java/com/leandrocourse/features/details/presentation/viewmodel/DetailsViewModel.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.features.details.presentation.viewmodel
 
+/**
+ * Handles state and events for the exchange details screen. It loads the
+ * selected exchange information and gradually builds the historical chart data
+ * used by the UI.
+ */
+
 import androidx.lifecycle.viewModelScope
 import com.leandrocourse.core.domain.usecase.SelectExchangeUseCase
 import com.leandrocourse.libraries.arch.viewmodel.ViewIntent

--- a/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/data/repository/ExchangesRepositoryImpl.kt
+++ b/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/data/repository/ExchangesRepositoryImpl.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.features.exchanges.data.repository
 
+/**
+ * Repository implementation that fetches exchange data from the remote data
+ * source. It acts as the bridge between the domain layer and network layer for
+ * the Exchanges feature.
+ */
+
 import com.leandrocourse.core.domain.model.Exchange
 import com.leandrocourse.features.exchanges.data.source.ExchangesRemoteDataSource
 import com.leandrocourse.features.exchanges.domain.repository.ExchangesRepository

--- a/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/presentation/viewmodel/ExchangesViewModel.kt
+++ b/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/presentation/viewmodel/ExchangesViewModel.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.features.exchanges.presentation.viewmodel
 
+/**
+ * ViewModel responsible for managing the state of the exchanges list screen.
+ * It reacts to user intents, loads data from use cases and exposes effects for
+ * navigation or error handling.
+ */
+
 import androidx.lifecycle.viewModelScope
 import com.leandrocourse.core.data.remote.model.ErrorType
 import com.leandrocourse.core.data.remote.network.exception.model.HttpThrowable

--- a/libraries/arch/src/main/java/com/leandrocourse/libraries/arch/viewmodel/ViewModel.kt
+++ b/libraries/arch/src/main/java/com/leandrocourse/libraries/arch/viewmodel/ViewModel.kt
@@ -1,5 +1,11 @@
 package com.leandrocourse.libraries.arch.viewmodel
 
+/**
+ * Base ViewModel used across the project to implement a simple
+ * unidirectional data flow. It exposes immutable state via a [StateFlow] and
+ * a channel for one-off effects such as navigation.
+ */
+
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow


### PR DESCRIPTION
## Summary
- expand README with Portuguese sections for project overview, architecture diagram, technologies, running instructions and main classes
- document classes such as `MainActivity`, repository implementations and ViewModels

## Testing
- `./gradlew test` *(fails: Unresolved reference: Config)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d0b0cfc8332bb184d908f56cc56