### PR TITLE
Fix volume formatting bug

### DIFF
--- a/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/presentation/component/formatVolume.kt
+++ b/features/exchanges/src/main/java/com/leandrocourse/features/exchanges/presentation/component/formatVolume.kt
@@ -11,7 +11,7 @@ import kotlin.math.pow
  */
 private const val DEFAULT_VALUE = "-"
 private const val THOUSAND = 1000.0
-private val SUFFIXES = charArrayOf('K', 'M', 'B')
+private val SUFFIXES = charArrayOf('K', 'M', 'B', 'T')
 private val DECIMAL_FORMAT = DecimalFormat("0.##")
 private val SUFFIX_FORMAT = "%.1f%c"
 
@@ -23,7 +23,9 @@ fun formatVolume(value: String?): String {
         if (number < THOUSAND) return DECIMAL_FORMAT.format(number)
 
         val exp = (ln(number) / ln(THOUSAND)).toInt()
-        String.format(SUFFIX_FORMAT, number / THOUSAND.pow(exp.toDouble()), SUFFIXES[exp - 1])
+        val index = (exp - 1).coerceAtMost(SUFFIXES.lastIndex)
+        val scaled = number / THOUSAND.pow((index + 1).toDouble())
+        String.format(SUFFIX_FORMAT, scaled, SUFFIXES[index])
     } catch (e: NumberFormatException) {
         value
     }

--- a/features/exchanges/src/test/java/com/leandrocourse/features/exchanges/presentation/component/FormatVolumeTest.kt
+++ b/features/exchanges/src/test/java/com/leandrocourse/features/exchanges/presentation/component/FormatVolumeTest.kt
@@ -1,0 +1,17 @@
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormatVolumeTest {
+    @Test
+    fun `formatVolume handles trillions`() {
+        // For 1,200,000,000,000 should display 1.2T after fix
+        val result = formatVolume("1200000000000")
+        assertEquals("1.2T", result)
+    }
+
+    @Test
+    fun `formatVolume returns raw value for invalid input`() {
+        val result = formatVolume("abc")
+        assertEquals("abc", result)
+    }
+}


### PR DESCRIPTION
## Summary
- handle large values in `formatVolume`
- add unit tests for the formatter

## Testing
- `./gradlew test --no-daemon` *(fails: unresolved references)*

------
https://chatgpt.com/codex/tasks/task_e_686b275836208332be92516c74ee47c6